### PR TITLE
Docs: Break apart the README across multiple services

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,143 +2,40 @@
 
 > A PromptQL-specific implementation of a docs bot.
 
-## Overview
+## What's Inside
 
-This all-in-one repository has two purposes:
+This repository demonstrates a complete PromptQL-powered chat bot for documentation sites:
 
-- Control development and deployment of our PromptQL-specific implementation of a chat bot for use in the PromptQL docs.
-- Illustrate the architecture and workflows necessary to use a PromptQL-powered application in the real world.
-
-You'll find the following structure, with the `pql` directory containing all PromptQL-related files and the `server`
-directory containing an Elysia server, written with Bun and TypeScript, acting as a proxy and providing a backend API
-which can be consumed by various frontends (e.g., a front-end chat component).
-
-```plaintext
-.
-├── pql
-├── server
-├── packages/chat-widget
-├── .dev.sh
-├── README.md
-├── compose.yaml
-└── ngrok.yml
-```
-
-## Architecture
-
-This repository contains:
-
-- **PromptQL Backend** (`pql/`) - PromptQL configuration and metadata for the docs bot
-- **API Server** (`server/`) - Elysia/Bun server providing chat endpoints
-- **Chat Widget** (`packages/chat-widget/`) - Reusable React component for embedding chat functionality
-
-### Chat Widget Package
-
-The `@pql/chat-widget` is a standalone React component that can be embedded in any documentation site or application. It
-provides:
-
-- Floating chat button with modal interface
-- Streaming message support
-- Light/dark/auto theme modes
-- TypeScript support
-- Minimal dependencies
-
-**Installation:**
-
-```sh
-npm install @pql/chat-widget
-```
-
-**Usage:**
-
-```tsx
-import { ChatWidget } from "@pql/chat-widget";
-import "@pql/chat-widget/styles";
-
-<ChatWidget serverUrl="http://localhost:3000" theme="auto" title="Documentation Chat" />;
-```
+- **PromptQL Backend** ([`pql/`](pql/README.md)) - AI agent configuration and data connectors
+- **API Server** ([`server/`](server/README.md)) - Elysia/Bun proxy server with streaming chat endpoints
+- **Chat Widget** ([`packages/chat-widget/`](packages/chat-widget/README.md)) - Embeddable React component for any site
 
 ## Quick Start
 
-Get the project running with just the essentials:
-
-### Prerequisites
-
-- [Docker](https://docs.docker.com/get-docker/)
-- [DDN CLI](https://promptql.io/docs/reference/cli/installation/)
-
-### Setup
-
-1. **Clone and navigate to the project:**
-
-   ```sh
-   git clone https://github.com/hasura/pql-docs-bot.git
-   cd pql-docs-bot
-   ```
-
-2. **Create environment files:**
-
-   ```sh
-   touch .env && cd pql && touch .env
-   ```
-
-   Fill them with the key-values from the **Product ACT** vault in 1Password (ask a team member for access if needed).
-
-3. **Start the server:**
-
-   ```sh
-   cd server && docker compose up -d
-   ```
-
-4. **Start PromptQL services:**
-   ```sh
-   cd pql && ddn run docker-start
-   ```
-
-That's it! Your PromptQL docs bot is now running locally.
-
-### Testing the Chat Widget
-
-To test chat widget changes locally:
+**Prerequisites**: [Docker](https://docs.docker.com/get-docker/) and
+[DDN CLI](https://promptql.io/docs/reference/cli/installation/)
 
 ```sh
-cd packages/chat-widget && bun run test
+# 1. Clone and setup
+git clone https://github.com/hasura/pql-docs-bot.git
+cd pql-docs-bot
+touch .env && cd pql && touch .env
+
+# 2. Add environment variables from 1Password (Product ACT vault)
+
+# 3. Start services
+cd server && docker compose up -d
+cd ../pql && ddn run docker-start
 ```
 
-This starts a test application that demonstrates the widget functionality. Make sure the server is running first, then
-open `http://localhost:3001` in your browser.
+Your docs bot is now running at `http://localhost:4000`
 
-## Contributing
+## Development
 
-Want to contribute or set up a full development environment? Check out [CONTRIBUTING.md](CONTRIBUTING.md) for:
+For enhanced development setup with tmux, hot reloading, and ngrok tunneling:
 
-- Enhanced development setup with tmux, Neovim, and ngrok
-- Development workflows and coding standards
-- Chat widget development using the included test app
-- How to contribute back to the project
+```sh
+chmod +x ./.dev.sh && ./.dev.sh
+```
 
-## CI/CD
-
-This repository includes automated PromptQL build and deployment workflows:
-
-### Build on Pull Request
-
-When you open a PR with changes to the `pql/` directory:
-
-- **Automatic build creation** using the DDN CLI
-- **PR comment** with build version and PromptQL playground link
-- **Comment updates** as you push new commits to the PR
-
-### Deploy on Merge
-
-When a PR merges to `main` with `pql/` changes:
-
-- **Automatic build application** to production
-- **Deployment confirmation** comment on the merged PR
-
-### Setup
-
-The workflows use 1Password for secure secret management. All secrets are stored in the **Product ACT** vault with the
-service account token configured as `OP_SERVICE_ACCOUNT_TOKEN` in GitHub repository secrets.
-
-See `.github/workflows/` for the complete workflow definitions.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed development workflows.

--- a/packages/chat-widget/README.md
+++ b/packages/chat-widget/README.md
@@ -1,0 +1,68 @@
+# Chat Widget
+
+Embeddable React component for adding PromptQL-powered chat to any documentation site.
+
+## Installation
+
+```sh
+npm install @pql/chat-widget
+```
+
+## Usage
+
+```tsx
+import { ChatWidget } from "@pql/chat-widget";
+import "@pql/chat-widget/styles";
+
+<ChatWidget
+  serverUrl="http://localhost:4000"
+  theme="auto"
+  title="Documentation Chat"
+  placeholder="Ask about PromptQL..."
+/>;
+```
+
+## Props
+
+| Prop          | Type                          | Default                | Description          |
+| ------------- | ----------------------------- | ---------------------- | -------------------- |
+| `serverUrl`   | `string`                      | -                      | Chat API server URL  |
+| `theme`       | `"light" \| "dark" \| "auto"` | `"auto"`               | Theme mode           |
+| `title`       | `string`                      | `"Documentation Chat"` | Chat window title    |
+| `placeholder` | `string`                      | `"Ask a question..."`  | Input placeholder    |
+| `className`   | `string`                      | -                      | Additional CSS class |
+
+## Features
+
+- 🎨 Light/dark/auto theme support
+- 📱 Responsive design
+- 💬 Streaming message support
+- ⚡ Minimal dependencies
+- 🔧 TypeScript support
+
+## Development
+
+```sh
+# Build the widget
+bun run build
+
+# Test with demo app
+bun run test
+# Opens http://localhost:3001
+```
+
+## Styling
+
+The widget includes default styles, but you can customize with CSS variables:
+
+```css
+.chat-widget {
+  --chat-primary-color: #your-color;
+  --chat-background: #your-bg;
+}
+```
+
+## Browser Support
+
+- Modern browsers with ES2018+ support
+- React 16.8+ (hooks support)

--- a/pql/README.md
+++ b/pql/README.md
@@ -1,0 +1,51 @@
+# PromptQL Backend
+
+The PromptQL configuration and AI agent setup for the docs bot.
+
+## Architecture
+
+- **AI Agent Configuration** (`globals/metadata/promptql-config.hml`) - System instructions and LLM settings
+- **Data Connectors** (`app/connector/`) - PostgreSQL for docs storage, TypeScript for embeddings and custom business
+  logic
+- **Metadata** (`app/metadata/`) - Supergraph schema and type definitions
+
+## Key Components
+
+### System Instructions
+
+The bot is configured as "DocsBot" with specific behavior patterns:
+
+- Lead with direct answers
+- Minimum viable responses
+- No marketing language
+- Always provide user-facing messages before actions
+
+### Data Layer
+
+- **PostgreSQL**: Stores documentation chunks and chat history
+- **TypeScript Connector**: Handles embedding generation and similarity search
+- **Hasura DDN**: Provides the unified data API
+
+## Development
+
+Start PromptQL services:
+
+```sh
+ddn run docker-start
+```
+
+This starts:
+
+- Query engine on port `3280`
+- All configured connectors
+- OpenTelemetry collector for observability
+
+## Configuration
+
+Environment variables in `.env`:
+
+- `ANTHROPIC_KEY` - Claude API key
+- `APP_PG_*` - PostgreSQL connection details
+- `HASURA_DDN_PAT` - DDN access token
+
+See [PromptQL documentation](https://promptql.io/docs/) for detailed configuration options.

--- a/server/README.md
+++ b/server/README.md
@@ -1,15 +1,60 @@
-# docs-bot
+# Chat API Server
 
-To install dependencies:
+Elysia/Bun server providing streaming chat endpoints for the PromptQL docs bot.
 
-```bash
+## Endpoints
+
+- `GET /` - Health check
+- `POST /chat/send` - Send message with streaming response
+
+## Streaming Response Format
+
+The server streams JSON chunks with the following structure:
+
+```json
+{
+  "success": true,
+  "conversationId": "uuid",
+  "step": "plan|code|message",
+  "plan": "...",
+  "code": "...",
+  "message": "...",
+  "timestamp": "2024-01-01T00:00:00.000Z"
+}
+```
+
+## Development
+
+```sh
+# Start with hot reloading (recommended)
+docker compose up
+
+# Or run directly with bun
 bun install
+bun --watch src/index.ts
+
+# Run tests
+bun test
 ```
 
-To run:
+## Production
 
-```bash
-bun run index.ts
+```sh
+# Build image
+docker build -t docs-bot-server .
 ```
 
-This project was created using `bun init` in bun v1.2.5. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.
+## Environment Variables
+
+Required in `.env`:
+
+- `SERVER_PORT` - Server port (default: 4000)
+- `PQL_API_KEY` - PromptQL API key
+
+## Integration
+
+The server acts as a proxy between frontend clients and the PromptQL backend, handling:
+
+- CORS for browser requests
+- Streaming response formatting
+- Error handling and logging


### PR DESCRIPTION
## Description

Cleaned up the documentation architecture to make it actually usable instead of one massive wall of text.

- Split monolithic root README into focused service-specific docs
- Moved technical details to where developers actually need them
- Created clear ownership boundaries for each component

## Previously...

The root README was doing everything - architecture explanations, detailed setup instructions, CI/CD workflows, chat widget documentation, and development guidelines all crammed into 200+ lines. Finding anything specific meant scrolling through irrelevant sections.

````markdown path=README.md mode=EXCERPT
## Overview

This all-in-one repository has two purposes:
- Control development and deployment of our PromptQL-specific implementation...
- Illustrate the architecture and workflows necessary to use a PromptQL-powered...

### Chat Widget Package

The `@pql/chat-widget` is a standalone React component that can be embedded...

**Installation:**
```sh
npm install @pql/chat-widget
```

## CI/CD

This repository includes automated PromptQL build and deployment workflows...
````

## Now...

The root README does one job: get someone from zero to running bot in under 30 seconds. Everything else lives where it belongs.

````markdown path=README.md mode=EXCERPT
## What's Inside

This repository demonstrates a complete PromptQL-powered chat bot for documentation sites:

- **PromptQL Backend** ([`pql/`](pql/README.md)) - AI agent configuration and data connectors
- **API Server** ([`server/`](server/README.md)) - Elysia/Bun proxy server with streaming chat endpoints
- **Chat Widget** ([`packages/chat-widget/`](packages/chat-widget/README.md)) - Embeddable React component for any site

## Quick Start

**Prerequisites**: [Docker](https://docs.docker.com/get-docker/) and [DDN CLI](https://promptql.io/docs/reference/cli/installation/)

```sh
# 1. Clone and setup
git clone https://github.com/hasura/pql-docs-bot.git
cd pql-docs-bot
touch .env && cd pql && touch .env

# 2. Add environment variables from 1Password (Product ACT vault)

# 3. Start services
cd server && docker compose up -d
cd ../pql && ddn run docker-start
```
````

Each service now has focused documentation that developers can actually use. The chat widget README explains props and styling. The server README covers endpoints and development workflow. The PromptQL README explains the AI configuration.

This follows the principle that documentation should be organized around user intent, not repository structure. Someone working on the chat widget doesn't need to wade through PromptQL configuration details to find React component props.
