### PR TITLE
CI: Add Slack notifications

### DIFF
--- a/.github/workflows/apply-build.yml
+++ b/.github/workflows/apply-build.yml
@@ -90,3 +90,41 @@ jobs:
               repo: context.repo.repo,
               body: comment
             });
+
+      - name: Update Slack thread
+        uses: actions/github-script@v7
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: |
+            // Find the thread timestamp
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const threadComment = comments.data.find(comment => 
+              comment.body.includes('<!-- slack-thread-ts:')
+            );
+
+            if (threadComment) {
+              const match = threadComment.body.match(/<!-- slack-thread-ts:([^-]+) -->/);
+              const threadTs = match ? match[1] : null;
+
+              if (threadTs) {
+                // Add checkmark reaction to original message
+                await fetch('https://slack.com/api/reactions.add', {
+                  method: 'POST',
+                  headers: {
+                    'Authorization': `Bearer ${process.env.SLACK_BOT_TOKEN}`,
+                    'Content-Type': 'application/json',
+                  },
+                  body: JSON.stringify({
+                    channel: process.env.SLACK_CHANNEL_ID || 'C1234567890',
+                    timestamp: threadTs,
+                    name: 'white_check_mark',
+                  }),
+                });
+              }
+            }

--- a/.github/workflows/create-build.yml
+++ b/.github/workflows/create-build.yml
@@ -101,3 +101,86 @@ jobs:
                 body: comment
               });
             }
+
+      - name: Notify Slack
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: |
+            const buildOutput = JSON.parse(`${{ steps.build.outputs.build_output }}`);
+
+            const slackMessage = `🚀 *PromptQL Build Complete*
+
+            *Build Version:* \`${buildOutput.build_version || 'N/A'}\`
+            *Project:* \`${buildOutput.project_name || 'pql-docs'}\`
+            *PromptQL Playground:* ${buildOutput.promptql_url ? buildOutput.promptql_url : 'N/A'}
+
+            ${buildOutput.description ? `*Description:* ${buildOutput.description}` : ''}`;
+
+            // Get or create Slack thread
+            const prKey = `pr_${context.payload.pull_request.number}`;
+
+            // Check if thread exists in PR metadata
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            let threadTs = null;
+            const threadComment = comments.data.find(comment => 
+              comment.body.includes('<!-- slack-thread-ts:')
+            );
+
+            if (threadComment) {
+              const match = threadComment.body.match(/<!-- slack-thread-ts:([^-]+) -->/);
+              threadTs = match ? match[1] : null;
+            }
+
+            if (!threadTs) {
+              // Create initial thread message
+              const prAuthor = context.payload.pull_request.user.login;
+              const prTitle = context.payload.pull_request.title;
+              const prNumber = context.payload.pull_request.number;
+              
+              const initialMessage = `<@${prAuthor}> opened a PR: #${prNumber} ${prTitle}`;
+              
+              const response = await fetch('https://slack.com/api/chat.postMessage', {
+                method: 'POST',
+                headers: {
+                  'Authorization': `Bearer ${process.env.SLACK_BOT_TOKEN}`,
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                  channel: process.env.SLACK_CHANNEL_ID || 'C1234567890', // Replace with your channel ID
+                  text: initialMessage,
+                }),
+              });
+
+              const slackData = await response.json();
+              threadTs = slackData.ts;
+
+              // Store thread timestamp in PR comment
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `<!-- slack-thread-ts:${threadTs} -->`
+              });
+            }
+
+            // Reply to thread with build info
+            await fetch('https://slack.com/api/chat.postMessage', {
+              method: 'POST',
+              headers: {
+                'Authorization': `Bearer ${process.env.SLACK_BOT_TOKEN}`,
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                channel: process.env.SLACK_CHANNEL_ID || 'C1234567890',
+                thread_ts: threadTs,
+                text: slackMessage,
+              }),
+            });


### PR DESCRIPTION
## Description

- Added Slack thread integration to PromptQL build workflows
- Creates dedicated threads for each PR with proper tagging and lifecycle management
- Provides real-time build notifications and merge confirmations

In testing for the internal FDE repo, this extends the ability of our CI to post in Slack. Before 👇 

```yaml
# Old workflow just commented on PRs
- name: Comment on PR
  uses: actions/github-script@v7
  with:
    script: |
      await github.rest.issues.createComment({
        body: comment
      });
```

Now we've wired up proper Slack integration that creates a complete audit trail:

```yaml
# New workflow creates Slack threads and tracks them
- name: Notify Slack
  uses: actions/github-script@v7
  env:
    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
  with:
    script: |
      const initialMessage = `<@${prAuthor}> opened a PR: #${prNumber} ${prTitle}`;
      // Creates thread, stores timestamp, replies with build info
```

The magic happens through thread timestamp persistence - we store the Slack thread ID in a hidden PR comment, then reference it across multiple workflow runs. When a PR opens, we create the thread. When builds complete, we reply to that same thread. When the PR merges, we add a checkmark reaction to the original message.

This gives us proper PR lifecycle visibility in Slack without flooding channels with disconnected messages. Each PR gets its own conversation thread that the whole team can follow from creation to production deployment.
