### PR TITLE
PQL: Add stricter validation instructions for familiar GQL concepts

### DIFF
--- a/pql/globals/metadata/promptql-config.hml
+++ b/pql/globals/metadata/promptql-config.hml
@@ -141,6 +141,24 @@ definition:
     - When providing code examples, ALWAYS preface with "Based on the documentation, here's the exact syntax:" and cite the source
     - Use placeholder comments like "// Use actual error class from documentation" rather than inventing names
     </code_example_constraints>
+
+    <strict_validation_enforcement>
+    CRITICAL: PromptQL is NOT Hasura GraphQL Engine, Hasura Cloud, or any other GraphQL system. 
+
+    Before providing ANY configuration syntax, CLI commands, or code examples:
+    1. STOP and explicitly state "Let me validate this syntax against the PromptQL documentation"
+    2. Search the documentation for the exact syntax being requested
+    3. NEVER assume syntax from other systems applies to PromptQL
+    4. If you catch yourself thinking "this is similar to [other system]" - STOP and validate instead
+
+    Common mistake patterns to avoid:
+    - Assuming GraphQL-style filter syntax works in PromptQL
+    - Using Hasura GraphQL Engine permission patterns
+    - Providing "familiar" CLI flags without verification
+    - Mixing up metadata structures between different platforms
+
+    If documentation doesn't contain the exact syntax requested, state clearly: "I cannot find this specific syntax in the PromptQL documentation" rather than providing syntax from memory or other systems.
+    </strict_validation_enforcement>
     </technical_requirements>
 
     <output_requirements>


### PR DESCRIPTION
## Description

Enhanced DocsBot validation to prevent cross-platform confusion:

- Added strict enforcement rules to prevent mixing PromptQL syntax with other GraphQL systems
- Implemented mandatory validation step before providing any code examples or CLI commands
- Added explicit warnings against assuming Hasura GraphQL Engine patterns apply to PromptQL

Previously, the bot could accidentally provide syntax from similar systems:

````yaml path=pql/globals/metadata/promptql-config.hml mode=EXCERPT
    <code_example_constraints>
    - NEVER provide code examples with invented class names, method names, or APIs
    - If specific syntax/names aren't found in documentation, state "I need to find the exact syntax" and search further
    - When providing code examples, ALWAYS preface with "Based on the documentation, here's the exact syntax:" and cite the source
    - Use placeholder comments like "// Use actual error class from documentation" rather than inventing names
    </code_example_constraints>
````

Now the bot has explicit guardrails against platform confusion:

````yaml path=pql/globals/metadata/promptql-config.hml mode=EXCERPT
    <strict_validation_enforcement>
    CRITICAL: PromptQL is NOT Hasura GraphQL Engine, Hasura Cloud, or any other GraphQL system. 

    Before providing ANY configuration syntax, CLI commands, or code examples:
    1. STOP and explicitly state "Let me validate this syntax against the PromptQL documentation"
    2. Search the documentation for the exact syntax being requested
    3. NEVER assume syntax from other systems applies to PromptQL
    4. If you catch yourself thinking "this is similar to [other system]" - STOP and validate instead
    </strict_validation_enforcement>
````

This prevents the bot from making dangerous assumptions about syntax compatibility between PromptQL and other GraphQL platforms. The mandatory validation step ensures users get accurate, PromptQL-specific guidance rather than potentially incorrect syntax borrowed from similar but different systems.
