### PR TITLE
PQL: Update sys instructions for branding

### DIFF
--- a/pql/globals/metadata/promptql-config.hml
+++ b/pql/globals/metadata/promptql-config.hml
@@ -10,7 +10,7 @@ definition:
     enable_automations: true
   systemInstructions: |    
     <system_role>
-    You are "DocsBot", the AI assistant for PromptQL documentation. Your primary goal is to unblock users quickly with minimal, actionable answers.
+    You are "DocsQL", the AI assistant for PromptQL documentation. Your primary goal is to unblock users quickly with minimal, actionable answers. Never break character and always be polite.
     </system_role>
 
     <core_execution_behaviors>
@@ -71,7 +71,7 @@ definition:
     <cli_validation_process description="Use only when providing CLI commands">
     Before providing any CLI command information to users, validate the command exists:
 
-    1. Check command existence: Query app.pql_docs_doc_content for pages with URLs matching:
+    1. Check command existence: Query app.pql_`docs`_doc_content for pages with URLs matching:
       https://promptql.io/docs/reference/cli/commands/ddn_[command]_[subcommand]/
       - Commands use underscores in URLs (e.g., ddn_connector_init)
       - Commands use spaces in actual CLI usage (e.g., ddn connector init)
@@ -177,12 +177,8 @@ definition:
     - Explicitly search for missing details: "Let me find the specific class names"
     - If still not found: Use the existing fallback pattern about searching documentation or GitHub
     </partial_information_handling>
-    <fallback_pattern>
-    Sorry. I couldn't find documentation for [specific topic]. Please search our documentation site or create an issue on our PromptQL GitHub repository (https://github.com/hasura/promptql/issues). If you are an Enterprise client, you can raise a ticket via https://hasurahelp.zendesk.com/hc/en-us/requests/new.
-    </fallback_pattern>
     </fallback_responses>
     
     <context_information>
     PromptQL is an agent platform for high-trust LLM interaction with business data. It uses Hasura DDN for the data layer and provides explainable, accurate results through composed tool calls.
     </context_information>
-


### PR DESCRIPTION
## Description

- Fixed bot identity from "DocsBot" to "DocsQL" 
- Added backticks around table name in CLI validation query
- Removed outdated fallback pattern with support links
- Cleaned up trailing whitespace

Now the configuration is cleaner and more consistent:

````yaml path=pql/globals/metadata/promptql-config.hml mode=EXCERPT
You are "DocsQL", the AI assistant for PromptQL documentation. Your primary goal is to unblock users quickly with minimal, actionable answers. Never break character and always be polite.
````

The changes ensure the bot maintains consistent identity as "DocsQL" throughout interactions.