### PR TITLE
Chore: Migrate to private ddn

### DIFF
--- a/server/src/routes/chat/sendMessage.ts
+++ b/server/src/routes/chat/sendMessage.ts
@@ -97,6 +97,7 @@ export const sendMessage = async ({ body, params, set, request }: Context) => {
     const token = await generateToken();
     const client = createPromptQLClientV2({
       apiKey: process.env.PQL_API_KEY || "",
+      baseUrl: "https://promptql.ddn.pro.hasura.io/api",
       ddn: {
         headers: {
           Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Description

- Migrated PromptQL configuration from public to private DDN deployment
- Updated client to target private DDN endpoint

Previously, the system was configured for the public DDN environment:

````yaml path=pql/.hasura/context.yaml mode=EXCERPT
contexts:
  default:
    project: pql-docs  # Public DDN project
````

````typescript path=server/src/routes/chat/sendMessage.ts mode=EXCERPT
const client = createPromptQLClientV2({
  apiKey: process.env.PQL_API_KEY || "",
  // Defaulting to public DDN endpoints
  ddn: {
    headers: {
      Authorization: `Bearer ${token}`,
    },
  },
});
````

Now the entire stack points to our private DDN deployment:

````yaml path=pql/.hasura/context.yaml mode=EXCERPT
contexts:
  default:
    project: docs-bot  # Private DDN project
````

````typescript path=server/src/routes/chat/sendMessage.ts mode=EXCERPT
const client = createPromptQLClientV2({
  apiKey: process.env.PQL_API_KEY || "",
  baseUrl: "https://promptql.ddn.pro.hasura.io/api",  // Private DDN endpoint
  ddn: {
    headers: {
      Authorization: `Bearer ${token}`,
    },
  },
});
````

This migration moves DocsQL from Hasura's public DDN to our private deployment, providing better isolation, enhanced controls, and dedicated resources. The `docs-bot` project name reflects our private namespace, while the explicit `baseUrl` ensures all PromptQL requests route through our controlled infrastructure rather than shared public endpoints.
