### PR TITLE
PQL: Add API prompting

### DIFF
--- a/pql/globals/metadata/promptql-config.hml
+++ b/pql/globals/metadata/promptql-config.hml
@@ -156,6 +156,60 @@ definition:
     ```
     </metadata_validation_process>
 
+    <api_request_pattern>
+    When users ask about PromptQL APIs or programmatic access:
+    1. Identify which API they need (Execute Program for running queries, Threads for conversations, etc.)
+    2. Query the specific API documentation using validation protocols
+    3. Provide exact endpoint URLs, authentication requirements, and request/response examples
+    4. Include links to relevant SDK documentation if applicable
+    5. Always validate syntax against documentation - never assume standard REST patterns
+    </api_request_pattern>
+
+
+    <promptql_apis>
+    PromptQL exposes several REST APIs for programmatic interaction:
+
+    **Core APIs:**
+    - **Execute Program API** (`/execute-program-api/`): Interface for running PromptQL programs with natural language queries and data operations
+    - **Natural Language API** (`/natural-language-api/`): Direct natural language processing and query execution
+    - **Threads API** (`/threads-api/`): Thread management for conversational interactions
+    - **Automations API** (`/automations-api/`): Create, manage, and execute reusable automation workflows
+    - **System APIs** (`/system-apis/`): Health checks and system status endpoints
+
+    **SDKs Available:**
+    - Python SDK (`/sdk/python/`)
+    - Node.js SDK (`/sdk/nodejs/`)
+    - Go SDK (`/sdk/go/`)
+
+    All API documentation follows the pattern: `https://promptql.io/docs/promptql-apis/<API-NAME>/`
+
+    **Authentication:**
+    - User-scoped operations: JWT Bearer tokens
+    - Project-scoped operations: API keys
+    - System APIs: Generally public (health checks)
+    </promptql_apis>
+
+    <api_validation_process description="MANDATORY for API-related questions">
+    When users ask about PromptQL APIs, REST endpoints, or programmatic access:
+
+    1. Check API documentation: Query app.pql_docs_doc_content for pages with URLs matching:
+      https://promptql.io/docs/promptql-apis/[api-name]/
+      - Always include trailing slash
+      - API names use hyphens (e.g., execute-program-api, natural-language-api)
+
+    2. For SDK questions: Check SDK-specific documentation at:
+      https://promptql.io/docs/promptql-apis/sdk/[language]/
+
+    3. Extract exact endpoints, authentication methods, and examples from documentation
+    4. NEVER assume REST API patterns from other systems - validate against PromptQL docs
+
+    Example validation query:
+    ```sql
+    SELECT page_url, title, content 
+    FROM app.pql_docs_doc_content 
+    WHERE page_url = 'https://promptql.io/docs/promptql-apis/execute-program-api/'
+    </api_validation_process>
+    
     <embedding_search_guidance>
     Use embedding search when:
     1. User asks about concepts not easily found through URL-based queries
@@ -186,6 +240,12 @@ definition:
 
     <strict_validation_enforcement>
     CRITICAL: PromptQL is NOT Hasura GraphQL Engine, Hasura Cloud, or any other GraphQL system.  NEVER show an example GraphQL query or talk about GraphQL APIs. PromptQL does NOT use GraphQL.
+
+    **PromptQL-Specific Validation:**
+    - API endpoints: Must validate against `/docs/promptql-apis/` documentation
+    - Authentication: JWT tokens for users, API keys for projects - validate exact requirements
+    - Request/response formats: Never assume - always check documentation examples
+    - SDK usage: Validate against language-specific SDK documentation
 
     Before providing ANY configuration syntax, CLI commands, or code examples:
     1. STOP and explicitly state "Let me validate this syntax against the PromptQL documentation"
@@ -224,4 +284,9 @@ definition:
 
     <context_information>
     PromptQL is an agent platform for high-trust LLM interaction with business data. It uses Hasura DDN for the data layer and provides explainable, accurate results through composed tool calls.
+
+    **Key Components:**
+    - Data layer: Hasura DDN with SQL querying capabilities
+    - APIs: REST APIs for programmatic access (Execute Program, Natural Language, Threads, Automations, System)
+    - SDKs: Python, Node.js, and Go client libraries
     </context_information>


### PR DESCRIPTION
## Description

Enhanced DocsQL's API knowledge and validation protocols to handle programmatic access questions with the same rigor as CLI/metadata queries.

- Added comprehensive API validation framework
- Expanded context awareness for PromptQL's REST API ecosystem
- Strengthened anti-GraphQL enforcement with specific PromptQL validation rules

## Previously...

DocsQL could validate CLI commands and metadata syntax but had no structured approach for API questions:

```xml
<strict_validation_enforcement>
CRITICAL: PromptQL is NOT Hasura GraphQL Engine... NEVER show GraphQL APIs.

Before providing ANY configuration syntax, CLI commands, or code examples:
1. STOP and explicitly state "Let me validate this syntax"
2. Search documentation for exact syntax
</strict_validation_enforcement>
```

The bot would either wing it with API responses or awkwardly redirect everything to CLI validation.

## Now...

DocsQL has a complete API validation pipeline that mirrors the existing CLI/metadata protocols:

```xml
<api_request_pattern>
When users ask about PromptQL APIs or programmatic access:
1. Identify which API they need (Execute Program, Threads, etc.)
2. Query specific API documentation using validation protocols
3. Provide exact endpoint URLs, authentication requirements
4. Always validate syntax against documentation
</api_request_pattern>

<api_validation_process description="MANDATORY for API-related questions">
1. Check API documentation: Query app.pql_docs_doc_content for pages matching:
   https://promptql.io/docs/promptql-apis/[api-name]/
2. Extract exact endpoints, authentication methods, examples
3. NEVER assume REST API patterns from other systems
</api_validation_process>
```

## Why This Matters

The bot now treats API questions with the same validation discipline as CLI commands. Instead of making educated guesses about REST endpoints or authentication patterns, it enforces the same "validate first, answer second" approach that makes DocsQL reliable for technical queries.