### PR TITLE
Chore: Migrate bot to different DP

### DIFF
--- a/pql/.hasura/context.yaml
+++ b/pql/.hasura/context.yaml
@@ -4,7 +4,7 @@ definition:
   current: default
   contexts:
     default:
-      project: docs-bot
+      project: docsql
       supergraph: ../supergraph.yaml
       subgraph: ../app/subgraph.yaml
       localEnvFile: ../.env

--- a/pql/app/connector/pg/.hasura-connector/Dockerfile.pg
+++ b/pql/app/connector/pg/.hasura-connector/Dockerfile.pg
@@ -1,2 +1,2 @@
-FROM ghcr.io/hasura/ndc-postgres-jdbc:v1.2.6
+FROM ghcr.io/hasura/ndc-postgres-jdbc:v1.2.16
 COPY ./ /etc/connector


### PR DESCRIPTION
Migrates the bot to the new `agents` data plane; also bumps the version of the Postgres connector.